### PR TITLE
AWS EB 배포 시 메모리 부족 에러 제거 (resolved #13)

### DIFF
--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -5,19 +5,22 @@
       "name": "frontend",
       "image": "modolee/multi-docker-frontend",
       "hostname": "frontend",
-      "essential": false
+      "essential": false,
+      "memory": 128
     },
     {
       "name": "api",
       "image": "modolee/multi-docker-api",
       "hostname": "api",
-      "essential": false
+      "essential": false,
+      "memory": 128
     },
     {
       "name": "worker",
       "image": "modolee/multi-docker-worker",
       "hostname": "worker",
-      "essential": false
+      "essential": false,
+      "memory": 128
     },
     {
       "name": "nginx",
@@ -30,7 +33,8 @@
           "containerPort": 80
         }
       ],
-      "links": ["frontend", "api"]
+      "links": ["frontend", "api"],
+      "memory": 128
     }
   ]
 }


### PR DESCRIPTION
# 반영 브랜치
master

# 해결 된 이슈 번호
resolved #13

# 변경 사항
Dockerrun.aws.json 파일에 메모리 속성 추가

# 확인 방법 (스크린샷 포함)
EB 대시보드에서 확인